### PR TITLE
Fix sqlite writing for unknown vertical levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpIO
 Title: IO functions and data wrangling for harp
-Version: 0.0.0.9160
+Version: 0.0.0.9161
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/write_fctable_to_sqlite.R
+++ b/R/write_fctable_to_sqlite.R
@@ -79,7 +79,7 @@ write_fctable_to_sqlite <- function(
 
   primary_key <- intersect(primary_key, colnames(data))
 
-  vertical_cols <- intersect(c("p", "ml", "z"), colnames(data))
+  vertical_cols <- intersect(c("p", "ml", "z", "level"), colnames(data))
   vertical_cols <- setdiff(vertical_cols, primary_key)
   if (length(vertical_cols) > 0) {
     message("Adding '", paste(vertical_cols, collapse = "','"), "' to index_cols.")
@@ -108,13 +108,21 @@ check_level <- function(df) {
       )
     }
     if (!level_type %in% c("pressure", "model", "height")) {
-      stop ("Unknown vertical coordinate: ", level_type, call. = FALSE)
+      if (length(unique(df[[level_type]])) < 2) {
+        return(df[!colnames(df) %in% c("level_type", "level")])
+      }
+      warning(
+        "Unknown vertical coordinate: ", level_type, "\n",
+        "Setting column name to 'level'.",
+        call. = FALSE
+      )
     }
     col_name <- switch(
       level_type,
       "pressure" = "p",
       "model"    = "ml",
-      "height"   = "z"
+      "height"   = "z",
+      "unknown"  = "level"
     )
     df <- replace_colname(df, "level", col_name)
     df <- df[!colnames(df) %in% c("level_type", "level")]


### PR DESCRIPTION
When input data are not on height, pressure or model levels (e.g. surface, mean sea level) the writing to sqlite stops as it doesn't know what to do with the 'level' column as described in #27. 

This PR fixes #27 by removing the level column if there is only one level, or keeping it if there are more than one and keeping the name 'level'. 

