### PR TITLE
Improvements when trying to read bad / unusual data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpIO
 Title: IO functions and data wrangling for harp
-Version: 0.0.0.9168
+Version: 0.0.0.9169
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/read_forecast.R
+++ b/R/read_forecast.R
@@ -510,13 +510,27 @@ read_forecast <- function(
     function_output <- lapply(function_output, spread_df)
 
     add_spatial_class <- function(df) {
+
       df <- dplyr::ungroup(df)
-      if (any(sapply(df, function(x) all(sapply(x, meteogrid::is.geofield))))) {
+
+      list_cols <- which(sapply(df, typeof) == "list")
+
+      for (df_col in list_cols) {
+        if (all(sapply(df[[df_col]], meteogrid::is.geofield))) {
+          if (!inherits(df[[df_col]], "geolist")) {
+            df[[df_col]] <- as_geolist(df[[df_col]])
+          }
+        }
+      }
+
+      if (any(sapply(df, function(x) inherits(x, "geolist")))) {
         if (!inherits(df, "harp_spatial_fcst")) {
           class(df) <- c("harp_spatial_fcst", class(df))
         }
       }
+
       df
+
     }
 
     function_output <- lapply(function_output, add_spatial_class)

--- a/R/read_grid.R
+++ b/R/read_grid.R
@@ -157,7 +157,8 @@ read_grid <- function(
     gridded_data <- tidyr::spread(gridded_data, key = "members", value = data_col)
   }
 
-  for (df_col in colnames(gridded_data)) {
+  list_cols <- which(sapply(gridded_data, typeof) == "list")
+  for (df_col in list_cols) {
     if (all(sapply(gridded_data[[df_col]], meteogrid::is.geofield))) {
       class(gridded_data[[df_col]]) <- c("geolist", class(gridded_data[[df_col]]))
     }

--- a/R/read_vfile.R
+++ b/R/read_vfile.R
@@ -121,7 +121,7 @@ read_vfile <- function(
 
   if (num_temp < 1) {
 
-    temp_data   <- empty_data
+    temp_data   <- dplyr::mutate(empty_data, p = NA_real_)
     params_temp <- data.frame(
       parameter        = character(),
       accum_hours      = integer(),

--- a/R/read_vfld_interpolate.R
+++ b/R/read_vfld_interpolate.R
@@ -147,7 +147,7 @@ read_vfld_interpolate <- function(
 
   # Extract the temp parameters
 
-  if (length(temp_parameters) > 0) {
+  if (length(temp_parameters) > 0 && nrow(tidyr::drop_na(vfld_data$temp)) > 0) {
     p_level_elements <- which(purrr::map_chr(temp_parameters, "level_type") == "pressure")
     if (length(p_level_elements) < length(temp_parameters)) {
       warning(

--- a/man/read_forecast.Rd
+++ b/man/read_forecast.Rd
@@ -24,7 +24,8 @@ read_forecast(
   output_file_opts = sqlite_opts(),
   return_data = FALSE,
   merge_lags = TRUE,
-  show_progress = FALSE
+  show_progress = FALSE,
+  stop_on_fail = FALSE
 )
 }
 \arguments{
@@ -143,6 +144,10 @@ unlagged members.}
 
 \item{show_progress}{Some files may contain a lot of data. Set to TRUE to
 show progress when reading these files.}
+
+\item{stop_on_fail}{Logical. Set to TRUE to make execution stop if there are
+problems reading a file. Missing files are always skipped regardless of
+this setting. The default value is FALSE.}
 }
 \value{
 When \code{return_date = TRUE}, a harp_fcst object.


### PR DESCRIPTION
Fixes #50 

Also:
- speeds up check for columns of geofields in `read_grid()` and `read_forecast()`
- Allows `read_forecast()` to continue if unreadable files are encountered. This behaviour can be switched off by setting `stop_on_fail = TRUE`
 