### PR TITLE
Make netcdf reading more agnostic of singleton dimensions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpIO
 Title: IO functions and data wrangling for harp
-Version: 0.0.0.9171
+Version: 0.0.0.9172
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/get_netcdf_param_info.R
+++ b/R/get_netcdf_param_info.R
@@ -110,8 +110,6 @@ get_netcdf_param_info <- function (param, vc = NA_character_, opts = netcdf_opts
   }
 
   if (opts[["options_set"]] %in% c("met_norway_eps", "met_norway_det"))  {
-    if (grepl("_+[[:digit:]]m$", netcdf_param)) opts[["z_var"]] <- "height1"
-    if (grepl("_0m$", netcdf_param)) opts[["z_var"]] <- "height0"
     if (grepl("surface", netcdf_param)) opts[["z_var"]] <- "height0"
   }
   if (opts[["options_set"]] %in% c("met_norway_ifsens", "met_norway_ifshires"))  {

--- a/R/read_netcdf.R
+++ b/R/read_netcdf.R
@@ -123,6 +123,8 @@ read_netcdf <- function(
     show_progress
   )
 
+  ncdf4::nc_close(nc_id)
+
   if (is.null(lead_time)) {
     result[["lead_time"]] = sapply(
       paste0(result[["lead_time"]], "s"),


### PR DESCRIPTION
When reading netcdf data, it is necessary to pass the names of all dimensions for a variable via `netcdf_opts()`. For singleton dimensions this can cause unwanted hassle. Now for singleton dimensions, the dimension name can be anything, as long as it exists as a dimensions in the netcdf file. 

Further improvements are needed so that the user doesn't have to specify the names of singleton dimensions at all. 

 