### PR TITLE
fix list specification for R < 4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpIO
 Title: IO functions and data wrangling for harp
-Version: 0.0.0.9173
+Version: 0.0.0.9174
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/setup_transformation.R
+++ b/R/setup_transformation.R
@@ -72,6 +72,10 @@ get_clim <- function(opts, trans) {
 
   } else {
 
+    if (is.null(opts[["clim_file_opts"]])) {
+      opts[["clim_file_opts"]] <- list()
+    }
+
     opts[["clim_file_opts"]][["first_only"]] <- TRUE
 
     opts[["clim_field"]] <- try(


### PR DESCRIPTION
This PR fixes #61, whereby in R >= 4 conversion of NULL to a named list is automatic with [[name]], but not in older versions of R. The list is now explicitly declared to ensure compatibility with R < 4. 