### PR TITLE
Pass changes to nc dim names back to calling function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpIO
 Title: IO functions and data wrangling for harp
-Version: 0.0.0.9174
+Version: 0.0.0.9175
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/read_netcdf.R
+++ b/R/read_netcdf.R
@@ -85,6 +85,10 @@ read_netcdf <- function(
   # Do the same if ensemble members are requested.
 
   nc_info <- lapply(param_info, make_nc_info, time_info, nc_id, file_name)
+
+  param_info <- lapply(nc_info, function(x) x[[2]])
+  nc_info    <- lapply(nc_info, function(x) x[[1]])
+
   if (all(sapply(nc_info, is.null))) {
     stop("Cannot read from netcdf file: ", file_name, call. = FALSE)
   }
@@ -246,7 +250,7 @@ make_nc_info <- function(param, info_df, nc_id, file_name) {
     info_df[["units"]] <- "unknown"
   }
 
-  info_df
+  list(info_df, param)
 }
 
 ###


### PR DESCRIPTION
When dimension names are modified as in #59 they weren't passed back to the calling function. This PR fixes that. 