### PR TITLE
Fix vfile reading when no SYNOP data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpIO
 Title: IO functions and data wrangling for harp
-Version: 0.0.0.9179
+Version: 0.0.0.9180
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/read_vfile.R
+++ b/R/read_vfile.R
@@ -62,6 +62,9 @@ read_vfile <- function(
       units            = character(),
       stringsAsFactors = FALSE
     )
+    if (v_version == 4) {
+      num_param    <- scan(file_connection, nmax = 1, quiet = TRUE)
+    }
 
   } else {
 


### PR DESCRIPTION
Fixes #73

When 0 synop records are indicated in the main header in a v-file, the synop header is still included with  another 0 to indicate the number of synop records (again). This line needs to be skipped when there are no synop data before moving on to read the rest of the file. 

This is certainly the case with vobs, so it is assumed that it is also the case for vfld. 