### PR TITLE
included tmax and tmin in min_val when units are in degC

### DIFF
--- a/R/gross_error_check.R
+++ b/R/gross_error_check.R
@@ -29,7 +29,7 @@ get_min_obs_allowed <- function(parameter, param_units = "") {
     "t"         = 173,
     -Inf
   )
-  if (tolower(parameter) %in% c("t2m", "td2m", "t") && param_units == "degC") {
+  if (tolower(parameter) %in% c("t2m", "td2m", "t", "tmax", "tmin") && param_units == "degC") {
     min_val <- min_val - 273.15
   }
   if (tolower(parameter) %in% c("pmsl", "ps") && param_units == "hPa") {


### PR DESCRIPTION
tmax and tmin were included in the check for degC in max_val but not in min_val