### PR TITLE
Bug fix for 12h precip observations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpIO
 Title: IO functions and data wrangling for harp
-Version: 0.0.0.9184
+Version: 0.0.0.9185
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]", 
     "Alex Deckmyn <alex.deckmyn@meteo.be> [aut]"

--- a/R/read_point_obs.R
+++ b/R/read_point_obs.R
@@ -134,7 +134,11 @@ read_point_obs <- function(
     vertical_level
   )
 
-  if (parameter %in% c("AccPcp3h", "AccPcp6h", "AccPcp12h") && any(grepl("AccPcp3h|AccPcp6h|AccPcp12h", colnames(obs)))) {
+  if (
+    parameter %in% c("AccPcp3h", "AccPcp6h", "AccPcp12h") &&
+      any(grepl("AccPcp3h|AccPcp6h|AccPcp12h", colnames(obs)))
+    ) {
+
     metadata_cols <- rlang::syms(colnames(obs)[colnames(obs) != parameter])
     message("Deriving 6h precipitation from 12h precipitation")
     obs <- derive_6h_precip(obs, available_files, date_start, date_end, stations)

--- a/R/read_point_obs.R
+++ b/R/read_point_obs.R
@@ -134,7 +134,7 @@ read_point_obs <- function(
     vertical_level
   )
 
-  if (parameter %in% c("AccPcp3h", "AccPcp6h", "AccPcp12h") && any(grepl("AccPcp3h|AccPcp6h", colnames(obs)))) {
+  if (parameter %in% c("AccPcp3h", "AccPcp6h", "AccPcp12h") && any(grepl("AccPcp3h|AccPcp6h|AccPcp12h", colnames(obs)))) {
     metadata_cols <- rlang::syms(colnames(obs)[colnames(obs) != parameter])
     message("Deriving 6h precipitation from 12h precipitation")
     obs <- derive_6h_precip(obs, available_files, date_start, date_end, stations)


### PR DESCRIPTION
A dodgy if statement meant that 12h precip was not computed from consecutive 6h precip observations in `read_point_obs()`. This PR fixes that and increases the number of available 12h precip observations. 