### PR TITLE
Default value for param_defs in is_synop/temp

### DIFF
--- a/R/parse_harp_parameter.R
+++ b/R/parse_harp_parameter.R
@@ -143,7 +143,7 @@ parse_harp_parameter <- function(
 }
 
 
-is_synop <- function(prm, vertical_coordinate = NA_character_, param_defs) {
+is_synop <- function(prm, vertical_coordinate = NA_character_, param_defs = getExportedValue("harpIO", "harp_params")) {
   # return TRUE if a parameter is a typical "synop"
   # ideally, we want this to be a "pure" logical: TRUE or FALSE, never "NA"
   if (!inherits(prm, "harp_parameter")) prm <- parse_harp_parameter(prm, vertical_coordinate)
@@ -168,7 +168,7 @@ is_synop <- function(prm, vertical_coordinate = NA_character_, param_defs) {
   result
 }
 
-is_temp <- function(prm, vertical_coordinate = NA_character_, param_defs) {
+is_temp <- function(prm, vertical_coordinate = NA_character_, param_defs = getExportedValue("harpIO", "harp_params")) {
   # return TRUE if a parameter is a typical "temp" (atmospheric)
   # infact you should look at level_type *and* level (not 0, 2 or 10)
   # ideally, we want this to be a "pure" logical: TRUE or FALSE, never "NA"


### PR DESCRIPTION
Otherwise read_point_forecast fails with:

```
Error in is_temp(parameter) : 
  argument "param_defs" is missing, with no default
```

where is_temp is used in:

```
harpIO/R/read_fctable.R:  if (!is.na(param$level_type) && is_temp(param) && !force_param_name) {
harpIO/R/read_point_forecast.R:    if (is_temp(parameter) && !force_param_name) {
harpIO/R/read_point_obs.R:  if (!is.null(harp_param$level_type) && is_temp(harp_param)) {
```