### PR TITLE
Allow for Ps reading from vfld

### DIFF
--- a/R/parse_harp_parameter.R
+++ b/R/parse_harp_parameter.R
@@ -152,6 +152,16 @@ is_synop <- function(prm, vertical_coordinate = NA_character_, param_defs = getE
     function(x) !is.null(x$v) && tolower(x$v$type) == "synop",
     logical(1)
   )]
+  par.synop.other <- names(param_defs)[vapply(
+    param_defs,
+    function(x) !is.null(x$v) && tolower(x$v$type) == "synop" && !is.null(x$other_names),
+    logical(1)
+  )]
+  par.synop.other <- unlist(lapply(param_defs[par.synop.other],function(x) x$other_names),
+                            use.names = F)
+  if (!is.null(par.synop.other)) {
+    par.synop <- c(par.synop,par.synop.other)
+  }
   sfc  <- switch(prm$level_type,
                 "sea"      = ,
                 "cloud"    = ,


### PR DESCRIPTION
At the moment Ps (surface pressure) is not read from the vfld as it is named "psfc" in harp_params (hence it is not found in par.synop in is_synop). Trying to read "psfc" does not work either as this column name is not found in the vfld data.

This suggests also looking for "other_names" in the synop parameter list when testing for is_synop. Confirmed that this works for "Ps" ("model_elevation" works now too). 

I don't think this will cause any unwanted behaviour, but I'm only skimming the surface. 

